### PR TITLE
Support for windows imagemagick path with spaces

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -36,7 +36,7 @@ function exec(command) {
       .then((mappedCli) => {
         //  We have the CLI path mapped, which means we can reconstruct the command
         //  with the appropriate path and execute it.
-        const reconstructedCommand = `${mappedCli} ${parameters}`;
+        const reconstructedCommand = `"${mappedCli}" ${parameters}`;
         childProcess.exec(reconstructedCommand, (err, stdout, stderr) => {
           if (err) {
             const errorMessage = `Failed to call '${command}', which was mapped to '${reconstructedCommand}'. Error is '${err.message}'.`;


### PR DESCRIPTION
My experience with node-imagemagick-cli is that it doesn't work if the "magick" executable's path (on Windows) contains one or more spaces. Since usually programs are installed on Windows under the "...\Program Files\..." path it could be a common situation.

I've made a small change in order to make it work; I've tested it under Windows and under OS X. I don't know if it also works under Linux.