### PR TITLE
fix(exec): add support for ImageMagick 7.0.1-Q16

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -29,8 +29,10 @@ function mapCli(cli) {
 
 function exec(command) {
   return new Promise((resolve, reject) => {
+    const safeCommand = /^convert /.test(command) ? `magick ${command}` : command;
+
     //  First, extract the cli and parameters.
-    const { cli, parameters } = deconstructCommand(command);
+    const { cli, parameters } = deconstructCommand(safeCommand);
 
     //  Map the cli to a path.
     mapCli(cli)

--- a/src/exec.js
+++ b/src/exec.js
@@ -8,7 +8,7 @@ const pickCli = require('./pick-cli');
 const cliPathsMap = {
 };
 
-function mapCli(cli) {
+async function mapCli(cli) {
   //  If we have already worked out the path to the CLI, great.
   if (cliPathsMap[cli]) return Promise.resolve(cliPathsMap[cli]);
 
@@ -20,33 +20,51 @@ function mapCli(cli) {
 
   //  On Windows we need to pick the right CLI, internally using the 'where'
   //  command.
-  return pickCli(cli)
+  let cliPath = await pickCli(cli)
     .then((mappedCli) => {
       cliPathsMap[cli] = mappedCli;
       return mappedCli;
     });
+
+  // On windows, path should contain "ImageMagick/"
+  if (/^win/.test(process.platform)) {
+    if (!/ImageMagick\//.test(cliPath)) {
+      // Try again searching for magick.exe
+      cliPath = await pickCli('magick')
+        .then((mappedCli) => {
+          cliPathsMap[cli] = mappedCli;
+          return mappedCli;
+        });
+      if (!cliPath) {
+        throw new Error('Could not find magick.exe. Is it installed in the default "ImageMagick" folder?');
+      }
+    }
+  }
+
+  return cliPath;
 }
 
 function exec(command) {
   return new Promise((resolve, reject) => {
-    const safeCommand = /^convert /.test(command) ? `magick ${command}` : command;
-
     //  First, extract the cli and parameters.
-    const { cli, parameters } = deconstructCommand(safeCommand);
+    const { cli, parameters } = deconstructCommand(command);
 
     //  Map the cli to a path.
     mapCli(cli)
       .then((mappedCli) => {
+        // Is this version 7.0.1-Q16?
+        const isV701Q16 = !mappedCli.includes(cli);
+
         //  We have the CLI path mapped, which means we can reconstruct the command
         //  with the appropriate path and execute it.
-        const reconstructedCommand = `"${mappedCli}" ${parameters}`;
+        const reconstructedCommand = `"${mappedCli}" ${isV701Q16 ? cli : ''} ${parameters}`;
         debug(`Preparing to execute: ${reconstructedCommand}`);
 
         childProcess.exec(reconstructedCommand, (err, stdout, stderr) => {
           debug(`  err: ${err ? err.toString() : '<null>'}`);
           debug(`  stdout: ${stdout}`);
           debug(`  stderr: ${stderr}`);
-          if (err) {
+          if (!stdout && err) {
             const errorMessage = `Failed to call '${command}', which was mapped to '${reconstructedCommand}'. Error is '${err.message}'.`;
             const error = new Error(errorMessage);
             error.stdout = stdout;


### PR DESCRIPTION
Command `$ convert` conflics with `C:\windows\system32\conver.exe` so to run image magic you must now use `$ magick convert <args>`.