### PR TITLE
Update exec.js

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -27,7 +27,11 @@ function mapCli(cli) {
     });
 }
 
-function exec(command) {
+function exec(command, bufferSize) {
+  let finalBuffer = { maxBuffer: 1024 * 500 };
+  if(bufferSize){
+  finalBuffer = bufferSize;
+  }
   return new Promise((resolve, reject) => {
     //  First, extract the cli and parameters.
     const { cli, parameters } = deconstructCommand(command);
@@ -40,7 +44,7 @@ function exec(command) {
         const reconstructedCommand = `"${mappedCli}" ${parameters}`;
         debug(`Preparing to execute: ${reconstructedCommand}`);
 
-        childProcess.exec(reconstructedCommand, (err, stdout, stderr) => {
+        childProcess.exec(reconstructedCommand, finalBuffer, (err, stdout, stderr) => {
           debug(`  err: ${err ? err.toString() : '<null>'}`);
           debug(`  stdout: ${stdout}`);
           debug(`  stderr: ${stderr}`);


### PR DESCRIPTION
in some situations the buffer size needs to be bigger so i made a extra parameter for the buffer

it will accept an object like {maxBuffer: 1024 * 500} this is for 500kb 

the default of node is just 200kb 